### PR TITLE
sof_{insert/remove}.sh: Add support for i.MX modules

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -75,6 +75,11 @@ insert_module snd_soc_max98390
 insert_module snd_soc_es8316
 insert_module snd_soc_es8326
 
+insert_module snd_soc_wm8960
+
+# core SOF driver
+insert_module snd_sof
+
 # insert top-level ACPI/PCI SOF drivers. They will register SOF components and
 # load machine drivers as needed. Do not insert any other sort of audio module,
 # code dependencies will be used to load the relevant modules.
@@ -95,6 +100,17 @@ insert_module snd_sof_pci_intel_cnl
 insert_module snd_sof_pci_intel_icl
 insert_module snd_sof_pci_intel_tgl
 insert_module snd_sof_pci_intel_mtl
+
+# OF driver
+insert_module snd_sof_of
+
+# helper drivers
+insert_module imx_common
+insert_module snd_sof_xtensa_dsp
+
+# i.MX specific drivers
+insert_module snd_sof_imx8
+insert_module snd_sof_imx8m
 
 # USB
 insert_module snd_usb_audio

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -88,6 +88,13 @@ remove_module snd_sof_pci_intel_mtl
 remove_module snd_sof_acpi_intel_byt
 remove_module snd_sof_acpi_intel_bdw
 
+#-------------------------------------------
+# Top level devices
+# i.MX-specific drivers
+#-------------------------------------------
+remove_module snd_sof_imx8
+remove_module snd_sof_imx8m
+
 #--------------------------------------------------
 # With older kernels this is in use by snd_sof_pci,
 # see https://github.com/thesofproject/linux/pull/2683
@@ -100,6 +107,7 @@ remove_module snd_sof_intel_hda_common || true
 remove_module snd_sof_acpi
 remove_module snd_sof_pci
 remove_module snd_sof_intel_atom
+remove_module imx_common
 
 #-------------------------------------------
 # legacy drivers (not used but loaded)
@@ -164,6 +172,11 @@ remove_module snd_sof_ipc_test
 remove_module snd_sof_ipc_flood_test
 remove_module snd_sof_ipc_msg_injector
 remove_module snd_sof_dma_trace
+
+#-------------------------------------------
+# SOF OF driver
+#-------------------------------------------
+remove_module snd_sof_of
 
 # snd_sof_nocodec dependencies re-ordered
 # in https://github.com/thesofproject/linux/pull/2800
@@ -231,6 +244,8 @@ remove_module snd_soc_dmic
 
 remove_module snd_hda_codec_realtek
 remove_module snd_hda_codec_generic
+
+remove_module snd_soc_wm8960
 
 #-------------------------------------------
 # Remaining core SOF parts


### PR DESCRIPTION
Added modules used by i.MX. This change will allow tests
based on module insertion/removal to work on i.MX.

Signed-off-by: Laurentiu Mihalcea <laurentiu.mihalcea@nxp.com>